### PR TITLE
Add support for custom HTTP headers via -h flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A CLI to evaluate MCP servers performance
 
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
-[![Version](https://img.shields.io/npm/v/mcp-eval.svg)](https://npmjs.org/package/mcp-eval)
-[![Downloads/week](https://img.shields.io/npm/dw/mcp-eval.svg)](https://npmjs.org/package/mcp-eval)
+[![Version](https://img.shields.io/npm/v/mcp-eval.svg)](https://npmjs.org/package/@alpic-ai/mcp-eval)
+[![Downloads/week](https://img.shields.io/npm/dw/mcp-eval.svg)](https://npmjs.org/package/@alpic-ai/mcp-eval)
 
 <!-- toc -->
 * [Quick start](#quick-start)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ test_cases:
 $ npx -y @alpic-ai/mcp-eval@latest run --url=https://mcp.github.com ./myserver.yml
 ```
 
+For servers requiring authentication, you can pass custom headers:
+
+```
+$ npx -y @alpic-ai/mcp-eval@latest run --url=https://nexus.civic.com/hub/mcp -h "Authorization: Bearer ACCESS_TOKEN" ./myserver.yml
+```
+
 - Et voilà 🎉!
 
 # Requirements
@@ -74,7 +80,7 @@ Run the test suite described in the provided YAML file.
 
 ```
 USAGE
-  $ mcp-eval run TESTFILE -u <value> [-a anthropic/claude]
+  $ mcp-eval run TESTFILE -u <value> [-a anthropic/claude] [-h <value>]
 
 ARGUMENTS
   TESTFILE  YAML file path containing the test suite
@@ -82,13 +88,16 @@ ARGUMENTS
 FLAGS
   -a, --assistant=<option>  [default: anthropic/claude] Assistant configuration to use (impact model and system prompt)
                             <options: anthropic/claude>
+  -h, --header=<value>...   Custom headers to send with requests (format: 'Header: value')
   -u, --url=<value>         (required) URL of the MCP server
 
 DESCRIPTION
   Run the test suite described in the provided YAML file.
 
 EXAMPLES
-  $ mcp-eval run
+  $ mcp-eval run myserver.yml --url=https://mcp.example.com
+
+  $ mcp-eval run myserver.yml --url=https://nexus.civic.com/hub/mcp -h "Authorization: Bearer TOKEN"
 ```
 
 _See code: [src/commands/run.ts](https://github.com/alpic-ai/mcp-eval/blob/v0.8.0/src/commands/run.ts)_

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A CLI to evaluate MCP servers performance
 
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
-[![Version](https://img.shields.io/npm/v/mcp-eval.svg)](https://npmjs.org/package/@alpic-ai/mcp-eval)
-[![Downloads/week](https://img.shields.io/npm/dw/mcp-eval.svg)](https://npmjs.org/package/@alpic-ai/mcp-eval)
+[![Version](https://img.shields.io/npm/v/@alpic-ai/mcp-eval.svg)](https://npmjs.org/package/@alpic-ai/mcp-eval)
+[![Downloads/week](https://img.shields.io/npm/dw/@alpic-ai/mcp-eval.svg)](https://npmjs.org/package/@alpic-ai/mcp-eval)
 
 <!-- toc -->
 * [Quick start](#quick-start)


### PR DESCRIPTION
Enables passing custom headers to MCP server requests using the -h/--header flag. Multiple headers can be specified by repeating the flag.

Example usage:
mcp-eval run test.yml -u https://example.com -h "Authorization: Bearer TOKEN" -h "X-Custom: value"
